### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,5 +37,9 @@ parts:
 apps:
   localsend-uno:
     command: localsend_app
-    extensions: [ gnome ]
-    plugs: [ home, network, network-manager ]
+    extensions: [gnome]
+    plugs:
+      - home
+      - removable-media # no auto-connect
+      - network
+      - network-manager # no auto-connect, enabling fixes AppArmor denials in log


### PR DESCRIPTION
added optional `removable-media` plug and turned list of plugs from horizontal to vertical